### PR TITLE
Fix duplicate sx identifier and missing sy identifier in touchstart

### DIFF
--- a/allegro.js
+++ b/allegro.js
@@ -300,7 +300,7 @@ function _touchstart(e)
 		var point = e.changedTouches.item(c);
 		var t = {
 			sx:point.clientX-rect.left,
-			sx:point.clientY-rect.top,
+			sy:point.clientY-rect.top,
 			mx:0,
 			my:0,
 			px:point.clientX-rect.left,


### PR DESCRIPTION
Touch start had duplicate identifier sx added to the touch_pressed array, replace second sx with sy